### PR TITLE
Feature/currency

### DIFF
--- a/backend/__tests__/app.test.ts
+++ b/backend/__tests__/app.test.ts
@@ -70,7 +70,10 @@ describe("createInvoiceHandler", () => {
 
     await createInvoiceHandler(client, body, res);
 
-    expect(client.callTool).toHaveBeenCalledWith({ name: "create-invoice", arguments: body });
+    expect(client.callTool).toHaveBeenCalledWith({
+      name: "create-invoice",
+      arguments: { ...body, expirySeconds: 604800 },
+    });
     expect(res.json).toHaveBeenCalledWith(result);
   });
 

--- a/backend/__tests__/price.test.ts
+++ b/backend/__tests__/price.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { getBitcoinPrice, resetCache } from "../src/price.js";
+
+const mockPrice = { bitcoin: { usd: 105000, mxn: 2100000 } };
+
+function mockFetch(response: unknown, ok = true) {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => response,
+  } as Response);
+}
+
+beforeEach(() => resetCache());
+afterEach(() => vi.restoreAllMocks());
+
+describe("getBitcoinPrice", () => {
+  it("fetches price from CoinGecko and returns usd and mxn", async () => {
+    mockFetch(mockPrice);
+
+    const price = await getBitcoinPrice();
+
+    expect(price.usd).toBe(105000);
+    expect(price.mxn).toBe(2100000);
+    expect(price.stale).toBeUndefined();
+  });
+
+  it("returns cached price on second call without fetching again", async () => {
+    mockFetch(mockPrice);
+
+    await getBitcoinPrice();
+    await getBitcoinPrice();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns stale cache when CoinGecko fails", async () => {
+    mockFetch(mockPrice);
+    await getBitcoinPrice();
+
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network error"));
+
+    vi.setSystemTime(Date.now() + 61_000);
+    const price = await getBitcoinPrice();
+
+    expect(price.usd).toBe(105000);
+    expect(price.stale).toBe(true);
+  });
+
+  it("throws when no cache and CoinGecko fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network error"));
+
+    await expect(getBitcoinPrice()).rejects.toThrow("No price data available");
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,8 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import express, { type Response } from "express";
 import { z } from "zod";
 
+import { getBitcoinPrice } from "./price.js";
+
 export const createInvoiceSchema = z.object({
   description: z.string().max(128),
   amountSat: z.number().optional(),
@@ -80,6 +82,15 @@ export async function listIncomingPaymentsHandler(client: Client, query: unknown
   }
 }
 
+export async function getPriceHandler(res: Response) {
+  try {
+    const price = await getBitcoinPrice();
+    res.json(price);
+  } catch {
+    res.status(503).json({ error: "Price data unavailable" });
+  }
+}
+
 export function createApp(client: Client) {
   const app = express();
   app.use(express.json());
@@ -88,6 +99,7 @@ export function createApp(client: Client) {
   app.post("/tool/create-invoice", (req, res) => createInvoiceHandler(client, req.body, res));
   app.post("/tool/pay-invoice", (req, res) => payInvoiceHandler(client, req.body, res));
   app.get("/tool/list-incoming-payments", (req, res) => listIncomingPaymentsHandler(client, req.query, res));
+  app.get("/price", (_req, res) => getPriceHandler(res));
 
   return app;
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 export const createInvoiceSchema = z.object({
   description: z.string().max(128),
   amountSat: z.number().optional(),
-  expirySeconds: z.number().optional(),
+  expirySeconds: z.number().optional().default(604800),
   externalId: z.string().optional(),
   webhookUrl: z.string().optional(),
 });

--- a/backend/src/price.ts
+++ b/backend/src/price.ts
@@ -1,0 +1,36 @@
+const COINGECKO_URL =
+  "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd,mxn";
+
+const CACHE_TTL_MS = 60_000;
+
+export type PriceData = {
+  usd: number;
+  mxn: number;
+  updatedAt: number;
+  stale?: boolean;
+};
+
+let cache: PriceData | null = null;
+
+export function resetCache() {
+  cache = null;
+}
+
+async function fetchFromCoinGecko(): Promise<PriceData> {
+  const res = await fetch(COINGECKO_URL);
+  if (!res.ok) throw new Error(`CoinGecko responded with ${res.status}`);
+  const data = await res.json() as { bitcoin: { usd: number; mxn: number } };
+  return { usd: data.bitcoin.usd, mxn: data.bitcoin.mxn, updatedAt: Date.now() };
+}
+
+export async function getBitcoinPrice(): Promise<PriceData> {
+  if (cache && Date.now() - cache.updatedAt < CACHE_TTL_MS) return cache;
+
+  try {
+    cache = await fetchFromCoinGecko();
+    return cache;
+  } catch {
+    if (cache) return { ...cache, stale: true };
+    throw new Error("No price data available");
+  }
+}

--- a/frontend/__tests__/App.test.tsx
+++ b/frontend/__tests__/App.test.tsx
@@ -2,19 +2,42 @@ import { render, screen } from "@testing-library/react";
 
 import App from "../src/App";
 
-beforeEach(() => {
-  vi.spyOn(globalThis, "fetch").mockResolvedValue({
-    ok: true,
-    json: async () => ({ content: [{ text: JSON.stringify({ balanceSat: 42000 }) }] }),
-  } as Response);
-});
+const mockPrice = { usd: 100000, mxn: 2000000, updatedAt: Date.now() };
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
+function mockFetch(balanceSat: number) {
+  vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
+    if (String(url).includes("price")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockPrice,
+      } as Response);
+    }
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ content: [{ text: JSON.stringify({ balanceSat }) }] }),
+    } as Response);
+  });
+}
 
-test("renders balance display", async () => {
+afterEach(() => vi.restoreAllMocks());
+
+test("renders balance in sat", async () => {
+  mockFetch(42000);
   render(<App />);
-
   expect(await screen.findByText(/sat/i)).toBeInTheDocument();
+});
+
+test("renders USD and MXN equivalent in balance header when price is available", async () => {
+  mockFetch(100000000);
+  render(<App />);
+  expect(await screen.findByText(/USD.*MXN/)).toBeInTheDocument();
+});
+
+test("shows Backend offline when balance fetch fails", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: false,
+    json: async () => ({}),
+  } as Response);
+  render(<App />);
+  expect(await screen.findByText(/backend offline/i)).toBeInTheDocument();
 });

--- a/frontend/__tests__/CurrencyInput.test.tsx
+++ b/frontend/__tests__/CurrencyInput.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { CurrencyInput } from "../src/components/CurrencyInput";
+
+const mockPrice = { usd: 100000, mxn: 2000000, updatedAt: Date.now() };
+
+beforeEach(() => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    json: async () => mockPrice,
+  } as Response);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+async function waitForPriceLoaded() {
+  await waitFor(() => expect(fetch).toHaveBeenCalled());
+  await waitFor(() => expect(screen.queryByText(/Fetching price/i)).not.toBeInTheDocument());
+}
+
+test("renders USD select and amount input", () => {
+  render(<CurrencyInput onSatsChange={() => {}} />);
+  expect(screen.getByRole("combobox")).toHaveValue("usd");
+  expect(screen.getByRole("spinbutton")).toBeInTheDocument();
+});
+
+test("shows sats conversion when amount is entered", async () => {
+  render(<CurrencyInput onSatsChange={() => {}} />);
+  await waitForPriceLoaded();
+
+  fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "1" } });
+
+  expect(await screen.findByText(/1,000/)).toBeInTheDocument();
+  expect(screen.getByText(/sat/i)).toBeInTheDocument();
+});
+
+test("calls onSatsChange with correct sats for USD", async () => {
+  const onSatsChange = vi.fn();
+  render(<CurrencyInput onSatsChange={onSatsChange} />);
+  await waitForPriceLoaded();
+
+  fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "1" } });
+
+  await waitFor(() => expect(onSatsChange).toHaveBeenCalledWith(1_000));
+});
+
+test("recalculates when currency changes to MXN", async () => {
+  const onSatsChange = vi.fn();
+  render(<CurrencyInput onSatsChange={onSatsChange} />);
+  await waitForPriceLoaded();
+
+  fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "1" } });
+  fireEvent.change(screen.getByRole("combobox"), { target: { value: "mxn" } });
+
+  await waitFor(() => expect(onSatsChange).toHaveBeenLastCalledWith(
+    Math.round((1 / 2_000_000) * 100_000_000),
+  ),
+  );
+});
+
+test("calls onSatsChange with null when amount is cleared", async () => {
+  const onSatsChange = vi.fn();
+  render(<CurrencyInput onSatsChange={onSatsChange} />);
+  await waitForPriceLoaded();
+
+  fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "1" } });
+  fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "" } });
+
+  await waitFor(() => expect(onSatsChange).toHaveBeenLastCalledWith(null));
+});

--- a/frontend/__tests__/usePrice.test.ts
+++ b/frontend/__tests__/usePrice.test.ts
@@ -1,0 +1,47 @@
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { usePrice } from "../src/hooks/usePrice";
+
+const mockPrice = { usd: 105000, mxn: 2100000, updatedAt: Date.now() };
+
+afterEach(() => vi.restoreAllMocks());
+
+test("fetches and returns price data", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    json: async () => mockPrice,
+  } as Response);
+
+  const { result } = renderHook(() => usePrice());
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
+
+  expect(result.current.price?.usd).toBe(105000);
+  expect(result.current.price?.mxn).toBe(2100000);
+  expect(result.current.error).toBe(false);
+});
+
+test("sets error when fetch fails", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: false,
+    json: async () => ({}),
+  } as Response);
+
+  const { result } = renderHook(() => usePrice());
+
+  await waitFor(() => expect(result.current.loading).toBe(false));
+
+  expect(result.current.error).toBe(true);
+  expect(result.current.price).toBeNull();
+});
+
+test("starts in loading state", () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    json: async () => mockPrice,
+  } as Response);
+
+  const { result } = renderHook(() => usePrice());
+
+  expect(result.current.loading).toBe(true);
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { getBalance } from "./api";
 import { History } from "./components/History";
 import { Receive } from "./components/Receive";
 import { Send } from "./components/Send";
+import { usePrice } from "./hooks/usePrice";
 
 type Tab = "receive" | "send" | "history";
 
@@ -13,10 +14,16 @@ const tabs: { id: Tab; label: string }[] = [
   { id: "history", label: "History" },
 ];
 
+function formatFiat(sats: number, btcPrice: number, currency: "USD" | "MXN") {
+  const amount = (sats / 100_000_000) * btcPrice;
+  return amount.toLocaleString("en-US", { style: "currency", currency, currencyDisplay: "code", maximumFractionDigits: 2 });
+}
+
 function App() {
   const [balance, setBalance] = useState<number | null>(null);
   const [balanceError, setBalanceError] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>("receive");
+  const { price } = usePrice();
 
   useEffect(() => {
     getBalance()
@@ -34,10 +41,17 @@ function App() {
           ) : balance === null ? (
             "Loading..."
           ) : (
-            <>
-              <span className="text-white text-2xl font-semibold">{balance}</span>
-              <span className="text-green-600 ml-1">sat</span>
-            </>
+            <div className="flex flex-col items-center gap-1">
+              <div>
+                <span className="text-white text-2xl font-semibold">{balance.toLocaleString()}</span>
+                <span className="text-green-600 ml-1">sat</span>
+              </div>
+              {price && (
+                <span className="text-neutral-400 text-xs">
+                  ≈ {formatFiat(balance, price.usd, "USD")} · {formatFiat(balance, price.mxn, "MXN")}
+                </span>
+              )}
+            </div>
           )}
         </div>
       </header>

--- a/frontend/src/components/CurrencyInput.tsx
+++ b/frontend/src/components/CurrencyInput.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+
+import { usePrice } from "../hooks/usePrice";
+
+type Currency = "usd" | "mxn";
+
+type Props = {
+  onSatsChange: (sats: number | null) => void;
+  placeholder?: string;
+};
+
+function toSats(amount: number, currency: Currency, btcPrice: { usd: number; mxn: number }) {
+  const price = currency === "usd" ? btcPrice.usd : btcPrice.mxn;
+  return Math.round((amount / price) * 100_000_000);
+}
+
+export function CurrencyInput({ onSatsChange, placeholder = "0.00" }: Props) {
+  const { price, loading } = usePrice();
+  const [currency, setCurrency] = useState<Currency>("usd");
+  const [amount, setAmount] = useState("");
+
+  function handleAmountChange(value: string) {
+    setAmount(value);
+    const num = parseFloat(value);
+    if (!price || isNaN(num) || num <= 0) {
+      onSatsChange(null);
+      return;
+    }
+    onSatsChange(toSats(num, currency, price));
+  }
+
+  function handleCurrencyChange(next: Currency) {
+    setCurrency(next);
+    const num = parseFloat(amount);
+    if (!price || isNaN(num) || num <= 0) {
+      onSatsChange(null);
+      return;
+    }
+    onSatsChange(toSats(num, next, price));
+  }
+
+  const sats = price && parseFloat(amount) > 0
+    ? toSats(parseFloat(amount), currency, price)
+    : null;
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-sm text-neutral-400">Amount</label>
+      <div className="flex gap-2">
+        <select
+          value={currency}
+          onChange={(e) => handleCurrencyChange(e.target.value as Currency)}
+          className="bg-neutral-700 text-white rounded-lg px-3 py-2 outline-none focus:ring-2 focus:ring-green-500"
+        >
+          <option value="usd">USD</option>
+          <option value="mxn">MXN</option>
+        </select>
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => handleAmountChange(e.target.value)}
+          placeholder={placeholder}
+          min={0}
+          step="0.01"
+          className="flex-1 bg-neutral-700 text-white rounded-lg px-4 py-2 outline-none focus:ring-2 focus:ring-green-500"
+        />
+      </div>
+      {loading && (
+        <p className="text-xs text-neutral-500">Fetching price...</p>
+      )}
+      {sats !== null && (
+        <p className="text-xs text-neutral-400">
+          ≈ <span className="text-white">{sats.toLocaleString()}</span> sat
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Receive.tsx
+++ b/frontend/src/components/Receive.tsx
@@ -4,9 +4,11 @@ import { QRCodeSVG } from "qrcode.react";
 
 import { createInvoice } from "../api";
 
+import { CurrencyInput } from "./CurrencyInput";
+
 export function Receive() {
   const [description, setDescription] = useState("");
-  const [amountSat, setAmountSat] = useState("");
+  const [amountSat, setAmountSat] = useState<number | null>(null);
   const [invoice, setInvoice] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -18,7 +20,7 @@ export function Receive() {
     setInvoice("");
     setLoading(true);
     try {
-      const result = await createInvoice(description, amountSat ? Number(amountSat) : undefined);
+      const result = await createInvoice(description, amountSat ?? undefined);
       setInvoice(result);
     } catch {
       setError("Failed to create invoice. Check the backend.");
@@ -51,17 +53,12 @@ export function Receive() {
             className="bg-neutral-700 text-white rounded-lg px-4 py-2 outline-none focus:ring-2 focus:ring-green-500"
           />
         </div>
-        <div className="flex flex-col gap-1">
-          <label className="text-sm text-neutral-400">Amount (sat) — optional</label>
-          <input
-            type="number"
-            value={amountSat}
-            onChange={(e) => setAmountSat(e.target.value)}
-            placeholder="any amount"
-            min={1}
-            className="bg-neutral-700 text-white rounded-lg px-4 py-2 outline-none focus:ring-2 focus:ring-green-500"
-          />
-        </div>
+
+        <CurrencyInput
+          onSatsChange={setAmountSat}
+          placeholder="leave empty for any amount"
+        />
+
         <button
           type="submit"
           disabled={loading}

--- a/frontend/src/hooks/usePrice.ts
+++ b/frontend/src/hooks/usePrice.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+
+export type PriceData = {
+  usd: number;
+  mxn: number;
+  updatedAt: number;
+  stale?: boolean;
+};
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+export function usePrice() {
+  const [price, setPrice] = useState<PriceData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  async function fetchPrice() {
+    try {
+      const res = await fetch("/price");
+      if (!res.ok) throw new Error("Price unavailable");
+      const data: PriceData = await res.json();
+      setPrice(data);
+      setError(false);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchPrice();
+    const interval = setInterval(fetchPrice, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  return { price, loading, error };
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
         target: "http://localhost:3000",
         changeOrigin: true,
       },
+      "/price": {
+        target: "http://localhost:3000",
+        changeOrigin: true,
+      },
     },
   },
   test: {


### PR DESCRIPTION
## Changes:
- Add backend `/price` endpoint with 60s in-memory cache backed by CoinGecko, with stale fallback on failure
- Add `usePrice` hook with 60s auto-refresh
- Add `CurrencyInput` component with USD/MXN selector and real-time sat conversion
- Show balance equivalent in USD and MXN in the header
- Integrate `CurrencyInput` into Receive tab replacing the manual sat input